### PR TITLE
fix: TypeScript compilation errors in daily reports workflow

### DIFF
--- a/.github/workflows/daily-store-reports.yml
+++ b/.github/workflows/daily-store-reports.yml
@@ -41,8 +41,8 @@ jobs:
     - name: Compile TypeScript
       run: |
         cd scripts/reports
-        npx tsc generate-store-report.ts --lib es2020 --module commonjs --target es2020
-        npx tsc insight-generator.ts --lib es2020 --module commonjs --target es2020
+        npx tsc generate-store-report.ts --lib es2020,dom --module commonjs --target es2020 --skipLibCheck true
+        npx tsc insight-generator.ts --lib es2020,dom --module commonjs --target es2020 --skipLibCheck true
     
     - name: Get active stores
       id: get_stores


### PR DESCRIPTION
## Summary
- Add DOM lib to TypeScript compilation for Supabase client compatibility
- Add skipLibCheck to avoid type definition conflicts
- Fixes WebSocket, Storage, BroadcastChannel, and other DOM type errors

## Details
The workflow was failing with TypeScript errors because the Supabase client library requires DOM type definitions. This PR adds:
- `--lib es2020,dom` to include DOM types
- `--skipLibCheck true` to skip type checking in node_modules

## Test Plan
- [x] Workflow compiles TypeScript files successfully
- [ ] Reports are generated without errors
- [ ] Emails are sent correctly