### PR TITLE
fix: Use correct Supabase URL secret name

### DIFF
--- a/.github/workflows/daily-store-reports.yml
+++ b/.github/workflows/daily-store-reports.yml
@@ -57,7 +57,7 @@ jobs:
     
     - name: Generate reports
       env:
-        NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+        NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
         SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
       run: |
         cd scripts/reports


### PR DESCRIPTION
The workflow was failing because it was looking for `NEXT_PUBLIC_SUPABASE_URL` but the secret is named `SUPABASE_URL`.

This PR updates the workflow to use the correct secret name that's already configured in the repository.