### PR TITLE
fix: Use actual store IDs and improve error handling

### DIFF
--- a/.github/workflows/daily-store-reports.yml
+++ b/.github/workflows/daily-store-reports.yml
@@ -52,7 +52,7 @@ jobs:
         else
           # In production, fetch from database
           # Default to Jack & Jones Arrábida and Omnia Guimarães stores
-          echo "store_ids=f47ac10b-58cc-4372-a567-0e02b2c3d479,f1234567-89ab-cdef-0123-456789abcdef" >> $GITHUB_OUTPUT
+          echo "store_ids=d719cc6b-1715-4721-8897-6f6cd0c025b0,e3c26903-7da5-4b09-9d43-abf93cd09f74" >> $GITHUB_OUTPUT
         fi
     
     - name: Generate reports
@@ -61,6 +61,10 @@ jobs:
         SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
       run: |
         cd scripts/reports
+        
+        # Create generated directory if it doesn't exist
+        mkdir -p generated
+        
         IFS=',' read -ra STORES <<< "${{ steps.get_stores.outputs.store_ids }}"
         
         for store_id in "${STORES[@]}"; do
@@ -70,7 +74,7 @@ jobs:
         
         # List generated reports
         echo "Generated reports:"
-        ls -la generated/
+        ls -la generated/ || echo "No reports generated"
     
     - name: Send email reports
       if: success()

--- a/scripts/reports/generate-store-report.ts
+++ b/scripts/reports/generate-store-report.ts
@@ -66,7 +66,7 @@ async function fetchStoreData(storeId: string): Promise<ReportData | null> {
       .from('stores')
       .select('id, name, code, timezone')
       .eq('id', storeId)
-      .single();
+      .maybeSingle();
     
     if (storeError || !store) {
       console.error('Error fetching store:', storeError);
@@ -87,7 +87,7 @@ async function fetchStoreData(storeId: string): Promise<ReportData | null> {
       .eq('store_id', storeId)
       .gte('date', yesterdayStart.toISOString())
       .lte('date', yesterdayEnd.toISOString())
-      .single();
+      .maybeSingle();
     
     if (!dailyData) {
       console.error('No daily data found for yesterday');
@@ -125,7 +125,7 @@ async function fetchStoreData(storeId: string): Promise<ReportData | null> {
       .eq('store_id', storeId)
       .gte('date', startOfDay(lastMonthDate).toISOString())
       .lte('date', endOfDay(lastMonthDate).toISOString())
-      .single();
+      .maybeSingle();
     
     // Fetch last week same day
     const lastWeekDate = subDays(yesterday, 7);
@@ -135,7 +135,7 @@ async function fetchStoreData(storeId: string): Promise<ReportData | null> {
       .eq('store_id', storeId)
       .gte('date', startOfDay(lastWeekDate).toISOString())
       .lte('date', endOfDay(lastWeekDate).toISOString())
-      .single();
+      .maybeSingle();
     
     // Calculate MTD (Month to Date) metrics
     const monthStart = new Date(yesterday.getFullYear(), yesterday.getMonth(), 1);


### PR DESCRIPTION
## Summary
- Use real store IDs that have sensor data in the database
- Improve error handling for missing store data
- Create directories before using them

## Changes
1. **Updated store IDs** to use actual production stores:
   - Jack & Jones Arrábida: `d719cc6b-1715-4721-8897-6f6cd0c025b0`
   - Omnia Guimarães: `e3c26903-7da5-4b09-9d43-abf93cd09f74`

2. **Improved error handling**:
   - Changed `.single()` to `.maybeSingle()` to handle cases where no data exists
   - This prevents the `PGRST116` error when stores have no data

3. **Directory management**:
   - Create `generated/` directory before use
   - Add fallback for `ls` command to avoid errors

## Testing
The workflow should now:
- Find actual store data in the database
- Handle missing data gracefully
- Generate reports successfully