### PR TITLE
fix: Analytics aggregation workflow script path

### DIFF
--- a/.github/workflows/run-analytics-aggregation-v2.yml
+++ b/.github/workflows/run-analytics-aggregation-v2.yml
@@ -51,8 +51,8 @@ jobs:
           
           # Run the existing aggregation script
           cd scripts
-          if [ -f "data-processing/run_hourly_aggregation.js" ]; then
-            node data-processing/run_hourly_aggregation.js
+          if [ -f "run_hourly_aggregation.js" ]; then
+            node run_hourly_aggregation.js
           else
             echo "⚠️ Aggregation script not found, skipping..."
           fi


### PR DESCRIPTION
## Summary
Fixed the analytics aggregation v2 workflow to use the correct script path.

## Changes
- Updated path from 
- To 🚀 Starting Hourly Analytics Aggregation
============================================================
📅 Current UTC time: 2025-07-24T12:30:29.353Z

📊 Attempting database function aggregation...
⚠️  Database function not available, using manual aggregation...

📊 Manual aggregation from 2025-07-24T09:30:29.668Z to 2025-07-24T12:30:29.668Z
Found 4 stores to process
  📝 Updated OML02 - Omnia Fórum Almada - 2025-07-24T11:00:00.000Z
  📝 Updated OML03 - Omnia NorteShopping - 2025-07-24T11:00:00.000Z
  📝 Updated J&J - 01 - ArrábidaShopping - 2025-07-24T11:00:00.000Z
  📝 Updated OML02 - Omnia Fórum Almada - 2025-07-24T10:00:00.000Z
  📝 Updated OML03 - Omnia NorteShopping - 2025-07-24T10:00:00.000Z
  📝 Updated J&J - 01 - ArrábidaShopping - 2025-07-24T10:00:00.000Z
  📝 Updated OML02 - Omnia Fórum Almada - 2025-07-24T09:00:00.000Z
  📝 Updated OML03 - Omnia NorteShopping - 2025-07-24T09:00:00.000Z
  📝 Updated J&J - 01 - ArrábidaShopping - 2025-07-24T09:00:00.000Z

📊 Processed 9 hourly records

📊 Recent Hourly Analytics:
Hour                     | Entries | Exits | Net Flow | Samples
-----------------------------------------------------------------
2025-07-24 11:00:00      |      98 |   121 |      -23 |       1
2025-07-24 11:00:00      |      88 |   142 |      -54 |       1
2025-07-24 11:00:00      |      22 |    29 |       -7 |       1
2025-07-24 10:00:00      |     159 |   111 |       48 |       1
2025-07-24 10:00:00      |      43 |    55 |      -12 |       1

✅ Aggregation completed successfully! (where the file actually exists)

## Impact
The analytics aggregation stage will now properly run the hourly aggregation instead of being skipped.

🤖 Generated with [Claude Code](https://claude.ai/code)