### PR TITLE
Fix: Analytics aggregation - match table schema and handle generated columns

### DIFF
--- a/scripts/run_hourly_aggregation.js
+++ b/scripts/run_hourly_aggregation.js
@@ -221,8 +221,8 @@ async function manualAggregation(supabaseUrl, supabaseKey) {
         sample_count: rawData.length,
         // Additional columns that exist in the table
         total_entries: totals.storeEntries,
-        total_exits: totals.storeExits,
-        net_flow: totals.storeEntries - totals.storeExits
+        total_exits: totals.storeExits
+        // net_flow is a generated column - don't insert it
       };
       
       // Add line data


### PR DESCRIPTION
## Summary
Complete fix to make the analytics aggregation work with the actual hourly_analytics table schema.

## Problems Fixed

### 1. Non-existent columns
The script was trying to insert columns that don't exist:
- ❌ `avg_occupancy`
- ❌ `peak_occupancy`  
- ❌ `occupancy_accuracy_score`

### 2. Generated column error
The script was trying to insert `net_flow` which is a generated column:
- Error: "cannot insert a non-DEFAULT value into column net_flow"
- Generated columns are calculated automatically by the database

## Solutions Implemented

1. **Removed non-existent columns** from the aggregation script
2. **Removed `net_flow`** from insert statements (it's auto-calculated)
3. **Added columns that do exist**: `total_entries`, `total_exits`
4. **Fixed column name mappings**: `hour_start` → `date` + `hour`
5. **Added comprehensive error logging** to diagnose issues

## Verified Table Schema
The hourly_analytics table has 49 columns. Key findings:
- ✅ `net_flow` is a generated column (auto-calculated as entries - exits)
- ✅ Uses `date` and `hour` columns (not `hour_start`)
- ✅ All line data columns exist (line1_in, line1_out, etc.)
- ✅ Zone metrics columns exist

## Files Changed
- `scripts/run_hourly_aggregation.js` - Main aggregation script
- `scripts/run_hourly_aggregation_simple.js` - Simplified backup version
- `.github/workflows/run-analytics-aggregation-v2.yml` - Updated workflow
- Various diagnostic scripts and SQL files

## Result
The aggregation now works correctly:
- ✅ No more column errors
- ✅ No more generated column errors
- ✅ Data successfully inserts/updates
- ✅ Regional metrics update properly

## Testing
The workflow has been tested and now successfully processes data for stores with raw data available.